### PR TITLE
Addition of other operating systems and *AMP stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,36 @@ BusKaro was conceived as a part of the end semester project for Course CS201 - D
 ## Installing
 
 - #### Windows
-  - Install [WAMP Server](http://www.wampserver.com/en/)
-  - Navigate to `(install location)/wamp/www`
-  - `git clone https://github.com/ajwad-shaikh/BusKaro.git`
-  - Start `(install location)/wamp/wampmanager.exe`
-  - Open Browser
-  - Go to `http://localhost/BusKaro`
+  - Install [WAMP Server](http://www.wampserver.com/en/) or [XAMPP Server](https://www.apachefriends.org/download.html)
+  - Navigate to the relevant  directory: 
+    - WAMP:   `(install location)/wamp/www` 
+    - XAMPP:  `(install location)/htdocs`
+  - Clone the repository: `git clone https://github.com/ajwad-shaikh/BusKaro.git`
+  - Start the server:
+    - WAMP:   `(install location)/wamp/wampmanager.exe`
+    - XAMPP:  `(install location)/xampp-control.exe`
+  - Open Browser and navigate to `http://localhost/BusKaro`
+
+- #### Apple
+  - Install [MAMP Server](https://www.mamp.info/en/downloads/)
+  - Navigate to `Applications/MAMP/htdocs/`
+  - Clone the repository: `git clone https://github.com/ajwad-shaikh/BusKaro.git`
+  - Start MAMP `Applications/MAMP/MAMP`
+  - Open Browser and navigate to 'http://localhost:80/BusKaro` 
+
+- #### Linux
+  - Install [LAMP Server](https://bitnami.com/stack/lamp/installer)
+  - Open the console (Ctrl + Alt + T) and navigate to the download location of the LAMP installation file
+  - Change permissions of the Bitnami LAMP file (change filname to the file you have downloaded):
+    `chmod +x bitnami-lampstack-YOUR-VERSION-linux-x64-installer.run`
+  - Start the installer:
+    `./bitnami-lampstack-YOUR-VERSION-linux-x64-installer.run`
+  - Follow the installation steps.
+    - Deselect *"Launch lampstack in the cloud with Bitnami"* when presented with the  *"Deploy lampstack to the Cloud in One Click"* window.
+  - Navigate to `/home/USERNAME/lampstack-YOUR-VERSION/apache2/htdocs/`
+  - Clone the repository: `git clone https://github.com/ajwad-shaikh/BusKaro.git`
+  - Start LAMP `/home/USERNAME/lampstack-YOUR-VERSION/manager-linux-x64.run`
+  - Open Browser and navigate to `http://localhost:8080/BusKaro/`
 
 ## Contributing
 


### PR DESCRIPTION
I have added XAMPP for Windows, MAMP for Apple and LAMP for Linux. 

I have double-checked installation instructions and have not encountered any issues with the instructions given. This however does not include Apple/OSX as I do not currently have a working computer with OSX installed.

Please review and see if these are the type of instructions you are looking for.

I would like to suggest that you add instruction files for each OS which can include the individual steps. These can then also include pictures to assist the user.

Please remove what you do not feel is adequate or deny the changes if you are not satisfied. If you are unsatisfied, please allow me to try again but with more details from your side so I know exactly what you are looking for.